### PR TITLE
Compiler Reborn

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ function gradientTransform(param) {
   return 'var img = new Image(); img.src = ' + base64Data + '; module.exports = img;';
 }
 
-function unownLoader(filepath, rootpath) {
+function unownCanon(filepath, rootpath) {
   // rootpath is the name of the folder where the require is called. Useful for relative require parsing, using _path.join_
+  canonicalName = someTransformation();
+  return canonicalName;
+}
+
+function unownLoader(filepath) {
+  // filepath passed is the resule of unownCanon
   var someJsTxt = something //your loader
   return 'module.exports = ' + someJsTxt;
 }
@@ -64,8 +70,11 @@ module.exports = {
       canonicalFunc: gradientCanon,
       transformFunc: gradientTransform
     },
-    '.unown': unownLoader
-  }
+    '.unown': { // If a custom canonicalization is needed
+      canonicalFunc: unownCanon,
+      transformFunc: unownLoader
+    },
+    '.unown': unownLoader // If no custom canonicalization is needed for this type
 };
 ```
 

--- a/bin/sald.js
+++ b/bin/sald.js
@@ -13,7 +13,7 @@ var usage = [
 
 switch(cmd) {
 	case "build":
-		var compiler = require('../lib/compiler.js');
+		var compiler = require('../lib/build.js');
 		compiler.compile();
 		break;
 	case "new":

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,0 +1,31 @@
+var dependencies = require('./dependencies.js');
+var transforms = require('./transforms.js');
+var path = require('path');
+var fs = require('fs');
+
+var buildParams = require(path.join(process.cwd(), 'build.js'));
+
+function build() {
+	var deps = dependencies.parse();
+
+	var template = fs.readFileSync(path.join(__dirname, '../template/build.js'), 'utf8');
+	var stringifiedDeps = [];
+
+	for (var dep in deps) {
+		if (!deps.hasOwnProperty(dep)) continue;
+		stringifiedDeps.push("'" + dep + "' : function(module) {\n" + deps[dep] + "}");
+	}
+
+	template = template.replace('{{snippets}}', stringifiedDeps.join(',\n'));
+	var normEntryPath = path.join(process.cwd(), buildParams.entry.js);
+	template = template.replace('{{entry}}', normEntryPath);
+
+	var html = fs.readFileSync(buildParams.entry.html, 'utf8');
+	var script = "<script>\n" + template + "\n</script>"
+	html = html.replace(/\<\s*scripts\s*\/\>|\<\s*scripts\s*\>\s*\<\s*\/scripts\s*\>/gm,script);
+	fs.writeFileSync(buildParams.output.html,html);
+}
+
+module.exports = {
+	compile: build
+}

--- a/lib/default_transforms.js
+++ b/lib/default_transforms.js
@@ -1,0 +1,52 @@
+var path = require('path');
+var fs = require('fs');
+
+function loadJavascript(filename) {
+	return fs.readFileSync(filename, 'utf8');
+}
+
+function canonicalFilepath(filepath, root) {
+	return path.normalize(path.join(root, filepath));
+}
+
+function loadFileGeneric(filepath, encoding) {
+	return fs.readFileSync(filepath, encoding);
+}
+
+function loadJSON(filepath) {
+	return 'module.exports = ' + loadFileGeneric(filepath, 'utf8') + ';';
+}
+
+function loadImageGeneric(mimeType, encoding) {
+	if (encoding == undefined) encoding = 'base64';
+	return function loadImage(file) {
+		var script = [
+			'var img = new Image();',
+			'img.src = "data:image/' + mimeType + ';' + encoding + ',' + loadFileGeneric(file, encoding) + '";',
+			'module.exports = img;'
+		].join('\n');
+		return script;
+	}
+}
+
+function loadAudioGeneric(mimeType, encoding) {
+	if (encoding == undefined) encoding = 'base64';
+	return function loadAudio(file) {
+		return 'module.exports = new Audio("data:audio/' + mimeType + ';' + encoding + ',' + file.data + '");';
+	}
+}
+
+function saldManagement(param) {
+	var libPath = path.join(__dirname, "../sald/", param);
+	return fs.readFileSync(libPath, 'utf8');
+}
+
+module.exports = {
+	'.js': loadJavascript,
+	'.jpg': loadImageGeneric('jpg'),
+	'.png': loadImageGeneric('png'),
+	'.ogg': loadAudioGeneric('ogg'),
+	'.wav': loadAudioGeneric('vnd.wave'),
+	'.json': loadJSON,
+	'sald:': saldManagement
+}

--- a/lib/default_transforms.js
+++ b/lib/default_transforms.js
@@ -5,10 +5,6 @@ function loadJavascript(filename) {
 	return fs.readFileSync(filename, 'utf8');
 }
 
-function canonicalFilepath(filepath, root) {
-	return path.normalize(path.join(root, filepath));
-}
-
 function loadFileGeneric(filepath, encoding) {
 	return fs.readFileSync(filepath, encoding);
 }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,0 +1,105 @@
+var fs = require('fs');
+var path = require('path');
+
+var transforms = require('./transforms.js');
+
+// process the javascript for a module
+// find its dependencies and add them to the list
+function processDependencies( blobs, cname, jstxt ){
+	// Filter out comments in the jstext
+	// jstxt = jstxt.replace(/(?:\/\*(?:[\s\S]*?)\*\/)|(?:([\s;])+\/\/(?:.*)$)/gm, '');
+
+	// find dependencies in the jstxt
+	// Match `require('*')` or `require("*")`
+	var reqRegExp = /require\s*\((?:\s*"[^"]*"|'[^']*'\s*)\)\s*/gm;
+	var reqs = jstxt.match(reqRegExp) || [];
+
+	// extract dependency 'names'
+	var stringRegExp = /"(.*)"|'(.*)'/;
+	var dependencies = reqs.map(function(req) {
+		var res = req.match(stringRegExp);
+		var file = res[1] || res[2];
+		if(!file) {
+			var arg = req.match(/require\s*\(\s*(.*)\s*\)\s*;/);
+			console.err(new Error("`" + arg[1] + "` is not a string literal."));
+		}
+		return res[1] || res[2];
+	});
+	
+	// recursively process the dependencies
+	for (var i = 0; i < dependencies.length; i ++)
+	{
+		var dependency = dependencies[i];
+		// 1. identify type of dependency
+		var is_literal = false;
+		var deptype;
+		var deptext;
+		if (dependency.match(/.*:.*/))
+		{
+			var parts = dependency.split(':');
+			deptype = parts[0] + ":";
+			deptext = parts[1];
+			is_literal = true;
+		}
+		else
+		{
+			deptype = path.extname(dependency);
+			if (deptype === "")
+			{
+				console.err(new Error("Invalid argument to \"require\": ") + dependency + " in required object: " + cname);
+				process.exit(1);
+			}
+			var fullname = path.join(path.dirname(cname), dependency);
+			deptext = fullname; //fs.readFileSync(fullname);
+		}
+
+		if (!transforms.hasOwnProperty(deptype))
+		{
+			console.error(new Error("Could not find a transform for dependency type: " + deptype));
+			process.exit(1);
+		}
+
+		// 2. generate canonical name for dependency
+		var depcname = transforms[deptype].canonicalFunc(dependency, cname);
+
+		// 3. replace argument to require() with canonical name
+		// var depRegEx = new RegExp("require\\(" + dependency + "\\)*");
+		// jstxt = jstxt.replace(depRegEx, "require(\"" + depcname + "\")");
+		jstxt = jstxt.replace(dependency, depcname);
+		
+		// 4. if the canonical name exists in the dependcy list - skip it
+		if (blobs.hasOwnProperty(depcname)) continue;
+
+		// 5. perform transform to generate a jstxt for the dependency
+		var depjs = transforms[deptype].transformFunc(deptext);
+
+		// 6. recursively process its dependencies
+		blobs[depcname] = ""; // prevent cyclical dependency
+		processDependencies( blobs, depcname, depjs );
+	}
+
+	// add the jstxt with canonical name to blobs
+	blobs[cname] = jstxt;
+}
+
+// top-level function - called by compiler
+function top()
+{
+	var buildParams = require(path.join(process.cwd(), 'build.js'));
+	// var entryfilename = transforms['sald:entry'];
+	var entryfilename = path.join(process.cwd(), buildParams.entry.js);
+
+	if (path.extname(entryfilename) !== '.js'){
+		print("Error - entry point must be a .js file!");
+		return [];
+	}
+
+	var jstxt = fs.readFileSync(entryfilename, {encoding:'utf8'});
+	var blobs = {}	
+	processDependencies( blobs, entryfilename, jstxt );
+	return blobs;
+}
+
+module.exports = {
+	parse: top
+};

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -50,7 +50,7 @@ function processDependencies( blobs, cname, jstxt ){
 				process.exit(1);
 			}
 			var fullname = path.join(path.dirname(cname), dependency);
-			deptext = fullname; //fs.readFileSync(fullname);
+			deptext = fullname;
 		}
 
 		if (!transforms.hasOwnProperty(deptype))
@@ -66,7 +66,7 @@ function processDependencies( blobs, cname, jstxt ){
 		// var depRegEx = new RegExp("require\\(" + dependency + "\\)*");
 		// jstxt = jstxt.replace(depRegEx, "require(\"" + depcname + "\")");
 		jstxt = jstxt.replace(dependency, depcname);
-		
+
 		// 4. if the canonical name exists in the dependcy list - skip it
 		if (blobs.hasOwnProperty(depcname)) continue;
 

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -1,0 +1,47 @@
+var path = require('path');
+var defaults = require('./default_transforms');
+var build;
+
+try {
+	build = require(path.join(process.cwd(), 'build.js'));
+} catch (err) {
+	switch(err.code) {
+		case 'MODULE_NOT_FOUND':
+			console.err('build.js not found, please ensure build.js is in cwd');
+			break;
+		default:
+			console.error(err); break;
+	}
+	process.exit(1);
+}
+
+var transforms = defaults;
+
+function canonicalString(s) {
+	return s;
+}
+
+function canonicalFilepath(f, root) {
+	return path.normalize(path.join(path.dirname(root), f));
+}
+
+var overrides = build.transforms;
+
+for (var prop in overrides) {
+	if (overrides.hasOwnProperty(prop)) {
+		transforms[prop] = overrides[prop];
+	}
+
+}
+
+for (var prop in transforms) {
+	if (typeof({}) != typeof(transforms[prop])) {
+		canonicalFunc = prop.match(/.*:.*/) ? canonicalString : canonicalFilepath;
+		transforms[prop] = {
+			transformFunc: transforms[prop],
+			canonicalFunc: canonicalFunc
+		}
+	}
+}
+
+module.exports = transforms;


### PR DESCRIPTION
Updated the build system to be more modular and generic.

Old `compiler.js` is left as is (just in case, but is dead code now).

Testbed project: https://github.com/prajwalkman/sald-town-adventure
(The require statements work, and everything is loaded as it should be. Somehow keyboard control doesn't work, but it shouldn't have anything to do with this. Possibly because it was coded against an older mainloop.)

Contributors:
Design: Prajwal, Adarsh, Steven
DependencyManagement: Prajwal, Felipe, Adarsh
Transformations: Prajwal, Adarsh
